### PR TITLE
Fix closing tab issue where the tabs are no longer returned

### DIFF
--- a/Main.cs
+++ b/Main.cs
@@ -44,8 +44,9 @@ namespace Flow.Launcher.Plugin.BrowserTabs
                             if (c.SpecialKeyState.CtrlPressed)
                             {
                                 tab.CloseTab();
-                                // Re-query to remove closed tab from the results
-                                Context.API.ChangeQuery(query.RawQuery, true);
+                                // Re-query to remove closed tab from the results.
+                                // Add a slight delay so re-query can pick up the tab elements again, 200ms was the right amount after testing
+                                Task.Delay(200).ContinueWith(_ => Context.API.ChangeQuery(query.RawQuery, requery: true));
                             }
                             else
                                 tab.ActivateTab();

--- a/plugin.json
+++ b/plugin.json
@@ -4,7 +4,7 @@
   "Name": "Browser Tabs",
   "Description": "Search, activate, or close browser tabs. A centralized plugin for managing all open tabs in your browser",
   "Author": "Jeremy Wu",
-  "Version": "1.0.0",
+  "Version": "1.0.1",
   "Language": "csharp",
   "Website": "https://github.com/Flow-Launcher/Flow.Launcher.Plugin.BrowserTabs",
   "ExecuteFileName": "Flow.Launcher.Plugin.BrowserTabs.dll",


### PR DESCRIPTION
Repro:
- Use action keyword `t` to bring up the list and closing a tab
- Repeat several times and will hit the issue where no tabs are returned after closing

Solution:
Add a slight delay to fix re-querying after closing tab